### PR TITLE
Add dockerized scanning, dependency checks, and samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Repository reconnaissance tool for vulnerability researchers.
 
-The tool profiles a repository to detect languages, web frameworks, and build systems. It uses `cloc` to identify languages and `semgrep` to search for framework usage. Support now covers Python, JavaScript, Go and Rust with basic framework and build system detection.
+The tool profiles a repository to detect languages, web frameworks, and build systems. It runs `cloc` and `semgrep` inside Docker containers to identify languages and framework usage. Support now covers Python, JavaScript, Go and Rust with basic framework and build system detection.
 
-After profiling, common static analysis tools are executed inside Docker containers (e.g. Semgrep and Gosec) and their findings are aggregated with a ranking of files containing the most issues.
+After profiling, common static analysis tools are executed inside Docker containers (e.g. Semgrep and Gosec) and their findings are aggregated with a ranking of files containing the most issues. Dependency manifests are scanned with `osv-scanner` for known vulnerabilities. Results are written to `report.sarif` and a detailed `report.md` describing all tools that were executed.
 
 ## Usage
 
@@ -18,4 +18,8 @@ The command line accepts:
 * `-exclude` – comma separated list of directories to skip during language detection (defaults to common virtual environment and dependency folders).
 * `-debug` – enable verbose logging.
 
-`cloc`, `semgrep`, and `docker` must be available in your `PATH`.
+Only `docker` must be available in your `PATH`; all other tooling runs inside containers.
+
+### Samples
+
+Sample projects for integration testing are located in the `samples/` directory.

--- a/main.go
+++ b/main.go
@@ -39,11 +39,9 @@ func main() {
 	}
 	repo := flag.Arg(0)
 
-	for _, b := range []string{"cloc", "semgrep", "docker"} {
-		if _, err := exec.LookPath(b); err != nil {
-			fmt.Printf("required binary %q not found in PATH\n", b)
-			os.Exit(1)
-		}
+	if _, err := exec.LookPath("docker"); err != nil {
+		fmt.Println("required binary \"docker\" not found in PATH")
+		os.Exit(1)
 	}
 
 	languages, err := detectLanguages(repo, excludeDir)
@@ -72,21 +70,34 @@ func main() {
 		fmt.Printf("%s: %v\n", lang, bs)
 	}
 
-	findings := runAnalyses(repo, languages)
+	findings, analysisTools := runAnalyses(repo, languages, frameworks)
+	depFindings, err := scanDependencies(repo)
+	if err != nil {
+		log.Printf("dependency scan failed: %v", err)
+	}
+
 	if len(findings) > 0 {
 		fmt.Println("Files with most findings:")
 		rankAndPrint(findings)
 	}
+
+	tools := append([]string{"cloc", "osv-scanner"}, analysisTools...)
+	if err := writeSARIF(findings, depFindings, "report.sarif"); err != nil {
+		log.Printf("failed to write SARIF: %v", err)
+	}
+	if err := writeMarkdown(languages, frameworks, buildsystems, findings, depFindings, tools, "report.md"); err != nil {
+		log.Printf("failed to write markdown: %v", err)
+	}
 }
 
 func detectLanguages(repo, exclude string) ([]string, error) {
-	args := []string{"--json"}
+	args := []string{"run", "--rm", "-v", repo + ":/src", "aldanial/cloc"}
 	if exclude != "" {
 		args = append(args, "--exclude-dir="+exclude)
 	}
-	args = append(args, repo)
-	log.Printf("running cloc %v", args)
-	cmd := exec.Command("cloc", args...)
+	args = append(args, "--json", "/src")
+	log.Printf("running docker %v", args)
+	cmd := exec.Command("docker", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -203,9 +214,10 @@ func runSemgrep(repo, lang, pattern string) bool {
 	return len(data.Results) > 0
 }
 
-func runAnalyses(repo string, languages []string) map[string]int {
+func runAnalyses(repo string, languages []string, frameworks map[string][]string) (map[string]int, []string) {
 	findings := map[string]int{}
 	seen := map[string]bool{}
+	tools := map[string]bool{}
 	for _, lang := range languages {
 		if seen[lang] {
 			continue
@@ -218,20 +230,48 @@ func runAnalyses(repo string, languages []string) map[string]int {
 		switch lang {
 		case "Go":
 			m, err = runGosec(repo)
+			if err == nil {
+				tools["gosec"] = true
+			}
 		default:
-			m, err = runSemgrepDocker(repo)
+			m, err = runSemgrepDocker(repo, "")
+			if err == nil {
+				tools["semgrep"] = true
+			}
 		}
 		if err != nil {
 			log.Printf("analysis for %s failed: %v", lang, err)
 			continue
 		}
 		mergeMaps(findings, m)
+		for _, fw := range frameworks[lang] {
+			if rule := frameworkRule(fw); rule != "" {
+				fm, err := runSemgrepDocker(repo, rule)
+				if err != nil {
+					log.Printf("framework scan %s failed: %v", fw, err)
+					continue
+				}
+				tools["semgrep"] = true
+				mergeMaps(findings, fm)
+			}
+		}
 	}
-	return findings
+	toolList := []string{}
+	for t := range tools {
+		toolList = append(toolList, t)
+	}
+	return findings, toolList
 }
 
-func runSemgrepDocker(repo string) (map[string]int, error) {
-	cmd := exec.Command("docker", "run", "--rm", "-v", repo+":/src", "returntocorp/semgrep", "semgrep", "--config=auto", "--json", "/src")
+func runSemgrepDocker(repo, config string) (map[string]int, error) {
+	args := []string{"run", "--rm", "-v", repo + ":/src", "returntocorp/semgrep", "semgrep", "--json"}
+	if config != "" {
+		args = append(args, "--config="+config)
+	} else {
+		args = append(args, "--config=auto")
+	}
+	args = append(args, "/src")
+	cmd := exec.Command("docker", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -274,6 +314,50 @@ func runGosec(repo string) (map[string]int, error) {
 	return counts, nil
 }
 
+func scanDependencies(repo string) (map[string]int, error) {
+	cmd := exec.Command("docker", "run", "--rm", "-v", repo+":/src", "ghcr.io/google/osv-scanner:latest", "--json", "-r", "/src")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var data struct {
+		Results []struct {
+			Source          string     `json:"source"`
+			Vulnerabilities []struct{} `json:"vulnerabilities"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(out, &data); err != nil {
+		return nil, err
+	}
+	counts := map[string]int{}
+	for _, r := range data.Results {
+		p := strings.TrimPrefix(r.Source, "/src/")
+		counts[p] = len(r.Vulnerabilities)
+	}
+	return counts, nil
+}
+
+func frameworkRule(f string) string {
+	switch strings.ToLower(f) {
+	case "django":
+		return "p/django"
+	case "flask":
+		return "p/flask"
+	case "express":
+		return "p/express"
+	case "gin":
+		return "p/gin"
+	case "echo":
+		return "p/echo"
+	case "rocket":
+		return "p/rocket"
+	case "actix":
+		return "p/actix"
+	default:
+		return ""
+	}
+}
+
 func mergeMaps(dst, src map[string]int) {
 	for k, v := range src {
 		dst[k] += v
@@ -293,4 +377,91 @@ func rankAndPrint(m map[string]int) {
 	for _, kv := range list {
 		fmt.Printf("%s: %d\n", kv.File, kv.Count)
 	}
+}
+
+func writeSARIF(code, deps map[string]int, path string) error {
+	type location struct {
+		PhysicalLocation struct {
+			ArtifactLocation struct {
+				URI string `json:"uri"`
+			} `json:"artifactLocation"`
+		} `json:"physicalLocation"`
+	}
+	type result struct {
+		RuleID  string `json:"ruleId"`
+		Message struct {
+			Text string `json:"text"`
+		} `json:"message"`
+		Locations []location `json:"locations"`
+	}
+	res := []result{}
+	for f, c := range code {
+		r := result{RuleID: "code"}
+		r.Message.Text = fmt.Sprintf("%d issues", c)
+		r.Locations = []location{{}}
+		r.Locations[0].PhysicalLocation.ArtifactLocation.URI = f
+		res = append(res, r)
+	}
+	for f, c := range deps {
+		r := result{RuleID: "dependency"}
+		r.Message.Text = fmt.Sprintf("%d vulnerabilities", c)
+		r.Locations = []location{{}}
+		r.Locations[0].PhysicalLocation.ArtifactLocation.URI = f
+		res = append(res, r)
+	}
+	sarif := map[string]interface{}{
+		"$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+		"version": "2.1.0",
+		"runs": []map[string]interface{}{
+			{
+				"tool":    map[string]interface{}{"driver": map[string]string{"name": "jkl"}},
+				"results": res,
+			},
+		},
+	}
+	b, err := json.MarshalIndent(sarif, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0644)
+}
+
+func writeMarkdown(langs []string, frameworks, builds map[string][]string, code, deps map[string]int, tools []string, path string) error {
+	var b strings.Builder
+	b.WriteString("# Scan Report\n\n")
+	b.WriteString("## Tools Run\n")
+	for _, t := range tools {
+		b.WriteString("- " + t + "\n")
+	}
+	b.WriteString("\n## Languages\n")
+	for _, l := range langs {
+		b.WriteString("- " + l + "\n")
+	}
+	b.WriteString("\n## Frameworks\n")
+	for lang, fws := range frameworks {
+		if len(fws) == 0 {
+			continue
+		}
+		b.WriteString(fmt.Sprintf("- %s: %v\n", lang, fws))
+	}
+	b.WriteString("\n## Build Systems\n")
+	for lang, bs := range builds {
+		if len(bs) == 0 {
+			continue
+		}
+		b.WriteString(fmt.Sprintf("- %s: %v\n", lang, bs))
+	}
+	if len(code) > 0 {
+		b.WriteString("\n## Code Findings\n\n| File | Findings |\n|---|---|\n")
+		for f, c := range code {
+			b.WriteString(fmt.Sprintf("| %s | %d |\n", f, c))
+		}
+	}
+	if len(deps) > 0 {
+		b.WriteString("\n## Dependency Findings\n\n| Manifest | Vulnerabilities |\n|---|---|\n")
+		for f, c := range deps {
+			b.WriteString(fmt.Sprintf("| %s | %d |\n", f, c))
+		}
+	}
+	return os.WriteFile(path, []byte(b.String()), 0644)
 }

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 }
 
 func detectLanguages(repo, exclude string) ([]string, error) {
-	args := []string{"run", "--rm", "-v", repo + ":/src", "aldanial/cloc"}
+	args := []string{"run", "--rm", "-v", repo + ":/src", "aldanial/cloc", "cloc"}
 	if exclude != "" {
 		args = append(args, "--exclude-dir="+exclude)
 	}

--- a/main.go
+++ b/main.go
@@ -272,7 +272,7 @@ func runAnalyses(repo string, languages []string, frameworks map[string][]string
 }
 
 func runSemgrepDocker(repo, config string) (map[string]int, error) {
-	args := []string{"run", "--rm", "-v", repo + ":/src", "returntocorp/semgrep", "semgrep", "scan", "--json"}
+	args := []string{"run", "--rm", "-v", repo + ":/src", "returntocorp/semgrep", "semgrep", "scan", "--json", "-q"}
 	if config != "" {
 		args = append(args, "--config="+config)
 	} else {
@@ -323,11 +323,9 @@ func runGosec(repo string) (map[string]int, error) {
 }
 
 func scanDependencies(repo string) (map[string]int, error) {
-	cmd := exec.Command("docker", "run", "--rm", "-v", repo+":/src", "ghcr.io/google/osv-scanner:latest", "--json", "-r", "/src")
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
+	cmd := exec.Command("docker", "run", "--rm", "-v", repo+":/src", "ghcr.io/google/osv-scanner:latest", "--format", "json", "--call-analysis", "-r", "/src")
+	//TODO: tool will return 0 or 1 for success, we should check that
+	out, _ := cmd.Output()
 	var data struct {
 		Results []struct {
 			Source          string     `json:"source"`

--- a/main.go
+++ b/main.go
@@ -272,7 +272,7 @@ func runAnalyses(repo string, languages []string, frameworks map[string][]string
 }
 
 func runSemgrepDocker(repo, config string) (map[string]int, error) {
-	args := []string{"run", "--rm", "-v", repo + ":/src", "returntocorp/semgrep", "--json"}
+	args := []string{"run", "--rm", "-v", repo + ":/src", "returntocorp/semgrep", "semgrep", "scan", "--json"}
 	if config != "" {
 		args = append(args, "--config="+config)
 	} else {

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,9 @@
+# Sample Projects
+
+These small projects are used for integration testing of the `jkl` tool.
+
+- `python` – Flask application with vulnerable dependencies in `requirements.txt`.
+- `node` – Express application with vulnerable dependencies in `package.json`.
+- `go` – Gin application with vulnerable dependencies in `go.mod`.
+
+Run the tool against any of these directories to exercise language, framework, and dependency scanning.

--- a/samples/go/go.mod
+++ b/samples/go/go.mod
@@ -1,0 +1,8 @@
+module go-sample
+
+go 1.20
+
+require (
+    github.com/gin-gonic/gin v1.7.0
+    github.com/dgrijalva/jwt-go v3.2.0+incompatible
+)

--- a/samples/go/main.go
+++ b/samples/go/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	_ = jwt.New(jwt.SigningMethodHS256)
+	r := gin.Default()
+	r.GET("/", func(c *gin.Context) { c.String(200, "Hello, Gin!") })
+	r.Run()
+}

--- a/samples/node/index.js
+++ b/samples/node/index.js
@@ -1,0 +1,4 @@
+const express = require('express');
+const app = express();
+app.get('/', (req, res) => res.send('Hello, Express!'));
+app.listen(3000);

--- a/samples/node/package.json
+++ b/samples/node/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "node-sample",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "4.17.1",
+    "lodash": "4.17.15"
+  }
+}

--- a/samples/python/app.py
+++ b/samples/python/app.py
@@ -1,0 +1,9 @@
+from flask import Flask
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return 'Hello, Flask!'
+
+if __name__ == '__main__':
+    app.run()

--- a/samples/python/requirements.txt
+++ b/samples/python/requirements.txt
@@ -1,0 +1,2 @@
+Flask==0.5
+requests==2.18.0


### PR DESCRIPTION
## Summary
- run cloc and semgrep via Docker and aggregate framework-specific rules
- scan dependency manifests with OSV and output SARIF and markdown reports
- add sample Go, Python, and Node projects for integration testing

## Testing
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_68979a561ef883298bf10484c5237116