### PR TITLE
Improve command execution logging and exit code handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -241,19 +241,23 @@ func parseJSON(b []byte, v interface{}) error {
 }
 
 func runSemgrepPatternDocker(repo, lang, pattern string) bool {
-	args := []string{"run", "--rm", "-v", repo + ":/src", "returntocorp/semgrep", "--json", "--lang", lang, "-e", pattern, "/src"}
-	cmd := exec.Command("docker", args...)
-	out, err := runCommand(cmd, 0, 1)
-	if err != nil {
-		return false
-	}
-	var data struct {
-		Results []struct{} `json:"results"`
-	}
-	if err := parseJSON(out, &data); err != nil {
-		return false
-	}
-	return len(data.Results) > 0
+        args := []string{
+                "run", "--rm", "-v", repo + ":/src",
+                "returntocorp/semgrep", "semgrep", "scan",
+                "--json", "-q", "--lang", lang, "-e", pattern, "/src",
+        }
+        cmd := exec.Command("docker", args...)
+        out, err := runCommand(cmd, 0, 1)
+        if err != nil {
+                return false
+        }
+        var data struct {
+                Results []struct{} `json:"results"`
+        }
+        if err := parseJSON(out, &data); err != nil {
+                return false
+        }
+        return len(data.Results) > 0
 }
 
 func runAnalyses(repo string, languages []string, frameworks map[string][]string) (map[string]int, []string) {


### PR DESCRIPTION
## Summary
- centralize command execution into `runCommand` with debug logs and exit code handling
- handle OSV scanner non-zero success codes and ensure JSON parsing errors are surfaced
- apply unified command runner across analysis helpers for consistent logging

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897ae75a5a48329bc2f5b11bc1dd64e